### PR TITLE
Update: create an ADR to adopt Hugo over Docusuarus to follow suit wi…

### DIFF
--- a/adr/0002-initial-architecture-for-unicorn-academy.md
+++ b/adr/0002-initial-architecture-for-unicorn-academy.md
@@ -6,6 +6,8 @@ Date: 2023-05-09
 
 Accepted
 
+Amended by [3. Use Hugo over Docusaurus for Unicorn Academy documentation](0003-use-hugo-over-docusaurus-for-unicorn-academy-documentation.md)
+
 ## Context
 
 Unicorn Academy currently exists only in a few people's heads.  This repo is the start of making it come to life.  Step 0 in enabling that is deciding where Unicorn Academy is going to live.

--- a/adr/0003-use-hugo-over-docusaurus-for-unicorn-academy-documentation.md
+++ b/adr/0003-use-hugo-over-docusaurus-for-unicorn-academy-documentation.md
@@ -1,0 +1,21 @@
+# 3. Use Hugo over Docusaurus for Unicorn Academy documentation
+
+Date: 2023-05-17
+
+## Status
+
+Accepted
+
+Amends [2. Initial architecture for Unicorn Academy](0002-initial-architecture-for-unicorn-academy.md)
+
+## Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+
+## Decision
+
+The change that we're proposing or have agreed to implement.
+
+## Consequences
+
+What becomes easier or more difficult to do and any risks introduced by the change that will need to be mitigated.


### PR DESCRIPTION
This ADR will partially supersede ADR 0002 in that Hugo will be used over Docusaurus for documentation in Unicorn Academy.  This follows suit with [what is being done elsewhere](https://github.com/defenseunicorns/product-adrs/blob/8b60ea661113e0ff30c9b6a6bb08777a6fb197f4/uds/0002-select-standard-documentation-framework-for-products.md) in the company.